### PR TITLE
Changed Active instances full updates to a button

### DIFF
--- a/client/fonts/material-symbols.css
+++ b/client/fonts/material-symbols.css
@@ -18,3 +18,13 @@
     white-space: nowrap;
     direction: ltr;
 }
+
+@keyframes material-symbol-spin {
+    100% {
+        transform:rotate(360deg);
+    }
+}
+
+.material-symbols-outlined.spinner {
+    animation:material-symbol-spin 4s linear infinite;
+}

--- a/client/frontend.js
+++ b/client/frontend.js
@@ -751,10 +751,12 @@ window.API.onFriendRequests((_event, friendRequests) => {
         acceptButton.append('✔');
         acceptButton.setAttribute('class', 'request-node--button-accept');
         acceptButton.addEventListener('click', () => window.API.acceptFriendRequest(friendRequest.id));
+        acceptButton.dataset.tooltip = 'Accept Friend Request';
         const declineButton = document.createElement('button');
         declineButton.append('✖');
         declineButton.setAttribute('class', 'request-node--button-reject');
         declineButton.addEventListener('click', () => window.API.declineFriendRequest(friendRequest.id));
+        declineButton.dataset.tooltip = 'Reject Friend Request';
         const buttonWrapper = document.createElement('div');
         buttonWrapper.setAttribute('class', 'request-node--button-wrapper');
         buttonWrapper.append(acceptButton, declineButton);
@@ -762,6 +764,7 @@ window.API.onFriendRequests((_event, friendRequests) => {
 
         // Append friendRequest Node element at the beginning
         homeRequests.prepend(friendRequestNode);
+        applyTooltips();
     }
 });
 

--- a/client/frontend.js
+++ b/client/frontend.js
@@ -1036,4 +1036,7 @@ setInterval(() => {
     });
 }, 30 * 60 * 1000);
 
+// Refresh active instances
+document.querySelector('#instances-refresh').addEventListener('click', _event => window.API.refreshInstances());
+
 applyTooltips();

--- a/client/frontend.js
+++ b/client/frontend.js
@@ -515,6 +515,9 @@ window.API.onActiveInstancesUpdate((_event, activeInstances) => {
     log('Active instances updated!');
     log(activeInstances);
 
+    // Disable spinner
+    document.querySelector('#instances-refresh').classList.toggle('spinner', false);
+
     // const activeInstances = [{
     //     "instanceSettingPrivacy": "Public",
     //     "privacy": "Public",
@@ -1037,6 +1040,10 @@ setInterval(() => {
 }, 30 * 60 * 1000);
 
 // Refresh active instances
-document.querySelector('#instances-refresh').addEventListener('click', _event => window.API.refreshInstances());
+document.querySelector('#instances-refresh').addEventListener('click', async _event => {
+    _event.target.classList.toggle('spinner', true);
+    const requestInitialized = await window.API.refreshInstances();
+    if (!requestInitialized) _event.target.classList.toggle('spinner', false);
+});
 
 applyTooltips();

--- a/client/index.html
+++ b/client/index.html
@@ -65,7 +65,9 @@
         </div>
         <div class="home-requests"></div>
         <div class="home-activity">
-          <h2>Instances<span class="home-activity--user-count">User Count</span></h2>
+          <h2>Instances
+            <button id="instances-refresh" class="home-activity--refresh material-symbols-outlined">refresh</button>
+            <span class="home-activity--user-count">User Count</span></h2>
           <div class="home-activity--activity-wrapper">
           </div>
         </div>

--- a/client/index.html
+++ b/client/index.html
@@ -66,7 +66,7 @@
         <div class="home-requests"></div>
         <div class="home-activity">
           <h2>Instances
-            <button id="instances-refresh" class="home-activity--refresh material-symbols-outlined">refresh</button>
+            <button id="instances-refresh" class="home-activity--refresh material-symbols-outlined" data-tooltip="Refresh Instances">refresh</button>
             <span class="home-activity--user-count">User Count</span></h2>
           <div class="home-activity--activity-wrapper">
           </div>

--- a/client/main-style.css
+++ b/client/main-style.css
@@ -421,6 +421,10 @@ button {
     margin-right: 5px;
 }
 
+.home-activity--refresh {
+    margin-right: auto;
+}
+
 .home-activity--user-count {
     float: right;
     font-size: small;

--- a/client/main-style.css
+++ b/client/main-style.css
@@ -423,6 +423,13 @@ button {
 
 .home-activity--refresh {
     margin-right: auto;
+    margin-left: 5px;
+    background-color: transparent;
+    border: none;
+}
+
+.home-activity--refresh:hover {
+    color: darkgrey;
 }
 
 .home-activity--user-count {

--- a/server/preload.js
+++ b/server/preload.js
@@ -54,7 +54,7 @@ contextBridge.exposeInMainWorld('API', {
     onWorldsByCategoryRefresh: (callback) => ipcRenderer.on('worlds-category-requests', callback),
 
     refreshUserStats: () => ipcRenderer.send('refresh-user-stats'),
-    refreshInstances: () => ipcRenderer.send('refresh-instances'),
+    refreshInstances: () => ipcRenderer.invoke('refresh-instances'),
     onUserStats: (callback) => ipcRenderer.on('user-stats', callback),
 
     refreshFriendRequests: () => ipcRenderer.send('refresh-friend-requests'),

--- a/server/preload.js
+++ b/server/preload.js
@@ -54,6 +54,7 @@ contextBridge.exposeInMainWorld('API', {
     onWorldsByCategoryRefresh: (callback) => ipcRenderer.on('worlds-category-requests', callback),
 
     refreshUserStats: () => ipcRenderer.send('refresh-user-stats'),
+    refreshInstances: () => ipcRenderer.send('refresh-instances'),
     onUserStats: (callback) => ipcRenderer.on('user-stats', callback),
 
     refreshFriendRequests: () => ipcRenderer.send('refresh-friend-requests'),


### PR DESCRIPTION
Proof of concept for now.

It has been bothering me that it's doing a huge amount of requests, just to keep that view updated with the non-friends people.

So I changed into:
- The first load does the full big requests to populate everything
- Over time the friends moving around will update the info on that view (but the non-friend people will stay in the same worlds since the initial load)
- There is a button next to the Instances that does a full refresh
- The full refresh is limited to be manually triggered once a minute (it will pop a toast saying how long left if you get limited)