### PR TITLE
Remove forcing the display of instances as private #40

### DIFF
--- a/client/frontend.js
+++ b/client/frontend.js
@@ -307,7 +307,7 @@ function getFriendStatus(friend) {
     if (!friend.isConnected) return { name: '', type: 'Offline Instance' };
     if (!friend.instance) return { name: '', type: 'Private Instance' };
     if (friend.instance.name) return {
-        name: friend.instance.privacy >= PrivacyLevel.Friends ? 'Private Instance' : friend.instance.name,
+        name: friend.instance.name,
         type: GetPrivacyLevelName(friend.instance.privacy),
     };
     return { name: 'Unknown', type: null };

--- a/server/data.js
+++ b/server/data.js
@@ -675,11 +675,6 @@ class Core {
             for (const friend of Object.values(this.friends)) {
                 if (!friend?.instance?.id) continue;
 
-                // Todo: When the websocket stops leaking the private instances info, we can remove this check so we
-                //  get info about Friends instance we do have access to...
-                // Ignore Friends and higher privacy levels
-                if (friend.instance.privacy >= CVRHttp.PrivacyLevel.Friends) continue;
-
                 // If the instance doesn't exist already, lets fetch it
                 if (!Object.prototype.hasOwnProperty.call(this.activeInstancesDetails, friend.instance.id)) {
                     try {


### PR DESCRIPTION
Title

The socket is not leaking instance info anymore