### PR TITLE
Updated to new API structure, added Friend Notes, and Public Content

### DIFF
--- a/server/api_cvr_http.js
+++ b/server/api_cvr_http.js
@@ -28,7 +28,7 @@ async function Post(url, data, authenticated = true) {
     try {
         const response = await (authenticated ? CVRApi : UnauthenticatedCVRApi).post(url, data);
         log.debug(`[Post] [${response.status}] [${authenticated ? '' : 'Non-'}Auth] ${url}`, response.data);
-        return response.data.data;
+        return response.data;
     }
     catch (error) {
         log.error(`[Post] [Error] [${authenticated ? '' : 'Non-'}Auth] ${url}`, error.toString(), error.stack);
@@ -72,7 +72,7 @@ exports.AuthenticateViaPassword = async (email, password) => {
     return await Authenticate(AuthMethod.PASSWORD, email, password);
 };
 async function Authenticate(authType, credentialUser, credentialSecret) {
-    const authentication = await Post('/users/auth', { AuthType: authType, Username: credentialUser, Password: credentialSecret }, false);
+    const authentication = (await Post('/users/auth', { AuthType: authType, Username: credentialUser, Password: credentialSecret }, false)).data;
     CVRApi = axios.create({
         baseURL: APIBase,
         headers: {
@@ -96,6 +96,10 @@ exports.GetMyFriendRequests = async () => await Get('/friends/requests');
 
 // Users
 exports.GetUserById = async (userId) => await Get(`/users/${userId}`);
+exports.GetUserPublicAvatars = async (userId) => await Get(`/users/${userId}/avatars`);
+exports.GetUserPublicWorlds = async (userId) => await Get(`/users/${userId}/worlds`);
+exports.GetUserPublicSpawnables = async (userId) => await Get(`/users/${userId}/spawnables`);
+exports.SetFriendNote = async (userId, note) => await Post(`/users/${userId}/note`, { note: note });
 
 // Avatars
 exports.GetMyAvatars = async () => await Get('/avatars');
@@ -104,7 +108,7 @@ exports.GetAvatarById = async (avatarId) => await Get(`/avatars/${avatarId}`);
 // Categories
 exports.GetCategories = async () => await Get('/categories');
 async function SetAvatarCategories(type, id, categoryIds) {
-    return Post('/categories/assign', {Uuid: id, CategoryType: type, Categories: categoryIds});
+    return (await Post('/categories/assign', {Uuid: id, CategoryType: type, Categories: categoryIds})).data;
 }
 exports.SetAvatarCategories = async (avatarId, categoryIds) => await SetAvatarCategories(CATEGORY_TYPES.AVATARS, avatarId, categoryIds);
 exports.SetFriendCategories = async (userId, categoryIds) => await SetAvatarCategories(CATEGORY_TYPES.FRIENDS, userId, categoryIds);

--- a/server/preload.js
+++ b/server/preload.js
@@ -40,7 +40,13 @@ contextBridge.exposeInMainWorld('API', {
 
     onImageLoaded: (callback) => ipcRenderer.on('image-load', callback),
 
+    // Users
     getUserById: (userId) => ipcRenderer.invoke('get-user-by-id', userId),
+    getUserPublicAvatars: (userId) => ipcRenderer.invoke('get-user-public-avatars', userId),
+    getUserPublicProps: (userId) => ipcRenderer.invoke('get-user-public-props', userId),
+    getUserPublicWorlds: (userId) => ipcRenderer.invoke('get-user-public-worlds', userId),
+    setFriendNote: (userId, note) => ipcRenderer.invoke('set-friend-note', userId, note),
+
     getWorldById: (worldId) => ipcRenderer.invoke('get-world-by-id', worldId),
     getInstanceById: (instanceId) => ipcRenderer.invoke('get-instance-by-id', instanceId),
 

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,3 +1,55 @@
 const { app } = require('electron');
 
+// const log = require('./logger').GetLogger('Utils');
+
 exports.GetUserAgent = () => `CVRX/${app.getVersion()} (deployment:${app.isPackaged ? 'production' : 'development'})`;
+
+
+/**
+ * Deep clones an object using JSON methods.
+ * This approach works for plain objects without circular references.
+ *
+ * @param {Object} obj - The object to be cloned.
+ * @returns {Object} The deep cloned object.
+ */
+exports.DeepClone = (obj) => {
+    return JSON.parse(JSON.stringify(obj));
+};
+
+/**
+ * Renames properties of an entity based on a given mapping.
+ *
+ * @param {Object} entity - The object to rename properties for.
+ * @param {Object} mapping - An object where keys are api property names and values are our property names.
+ * @returns {Object} The entity with renamed properties.
+ */
+exports.MapEntity = (entity, mapping) => {
+
+    // If it's an array, handle each entity separately
+    if (Array.isArray(entity)) {
+        const result = [];
+        for (const entityElement of entity) {
+            result.push(exports.MapEntity(entityElement, mapping));
+        }
+        return result;
+    }
+
+    const entityToMap = { ...entity };
+
+    for (let apiKey in mapping) {
+        if (Object.prototype.hasOwnProperty.call(entityToMap, apiKey)) {
+            const ourKey = mapping[apiKey];
+            // If the mapping is an object, it means it's a nested mapping
+            if (typeof ourKey === 'object' && ourKey !== null) {
+                entityToMap[ourKey.root] = exports.MapEntity(entityToMap[apiKey], ourKey.mapping);
+            }
+            // Otherwise let's just fix the key
+            else {
+                entityToMap[ourKey] = entityToMap[apiKey];
+            }
+            delete entityToMap[apiKey];
+        }
+    }
+
+    return entityToMap;
+};


### PR DESCRIPTION
## Changes
- Updated the API to match the currently used one.
- Added endpoints to set notes on friends. The note is sent with the user details.
- Added endpoints for getting a user's public avatars, worlds, and props.

### Notes
Set a note example: `await window.API.setFriendNote('xxxxxxxx-1d3b-4aff-defb-c167ed99b416', 'This is a note');`

The notes are obtainable in the get user details endpoint, the property is called `note`

The note can have a maximum of `512` characters.

The endpoint will throw errors with the following codes:
- `400` Invalid Request Body
- `406` Friend Note is longer than Max Characters (512)
- `412` User must be friended to set a Friend Note

### User's public content
Get user's public avatars: `await window.API.getUserPublicAvatars('xxxxxxxx-1d3b-4aff-defb-c167ed99b416');`
Get user's public worlds: `await window.API.getUserPublicAvatars('xxxxxxxx-1d3b-4aff-defb-c167ed99b416');`
Get user's public props: `await window.API.getUserPublicAvatars('xxxxxxxx-1d3b-4aff-defb-c167ed99b416');`

The response should as follow (for all 3 types):
```js
const entries = [{
         id: 'xxxxxxxx-f914-40c2-833b-eb94e7099a97',
         name: "E-Bumpin'",
         imageUrl: 'https://files.abidata.io/user_content/spawnables/xxxxxxxx-f914-40c2-833b-eb94e7099a97/xxxxxxxx-f914-40c2-833b-eb94e7099a97.png',
         imageHash: "6640ace56daa29722f2ac490d4a439f82bd75eeb"
}];
```